### PR TITLE
Updated Travis CI Golang testing versions for 2020.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: go
 
 go:
+  # n.b. For golang release history, see https://golang.org/doc/devel/release.html
   - tip
-  - "1.10"
-  - 1.9
-  - 1.8
-  - 1.7
-  - 1.6
+  - "1.13.8"
+  - "1.12.17"
+  - "1.11.13"
+  - "1.10.8"
+  - "1.9.7"
 
 services:
   - postgresql

--- a/repository/gorm_driver.go
+++ b/repository/gorm_driver.go
@@ -17,9 +17,8 @@ import (
 
 	"github.com/gigawattio/driver/repository/gormlib"
 	"github.com/gigawattio/errorlib"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/jinzhu/gorm"
+	log "github.com/sirupsen/logrus"
 )
 
 type (

--- a/repository/gorm_driver_test.go
+++ b/repository/gorm_driver_test.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/gigawattio/driver/repository/gormlib"
 	"github.com/gigawattio/testlib"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/jinzhu/gorm"
+	log "github.com/sirupsen/logrus"
 )
 
 type (

--- a/repository/gormlib/gorm_utils.go
+++ b/repository/gormlib/gorm_utils.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq" // Imported for postgres-driver lib side effects.
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
- Added Go versions 1.9.7, 1.10.8, 1.11.13, 1.12.17, and 1.13.8.
- Dropped Go versions 1.6, 1.7, 1.8, 1.9, and 1.10.
